### PR TITLE
update syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@ Print fancy messages to the terminal.
 This assumes you've included this repository under `/wren-colors` in your project root.
 
 ```dart
-import 'wren-colors/index' for AnsiColors, AnsiPrinter
+import "wren-colors/index" for AnsiColors, AnsiPrinter
 
-var a = new AnsiPrinter(AnsiColors.BLUE, AnsiColors.WHITE_B, AnsiColors.BLINK)
+var a = AnsiPrinter.new(AnsiColors.BLUE, AnsiColors.WHITE_B, AnsiColors.BLINK)
 a.print("This text should be blue on a white background and blink.")
 
-var b = new AnsiPrinter(AnsiColors.BLUE, AnsiColors.WHITE_B)
+var b = AnsiPrinter.new(AnsiColors.BLUE, AnsiColors.WHITE_B)
 b.print("This text should be blue on a white background.")
 
-var c = new AnsiPrinter(AnsiColors.BLUE)
+var c = AnsiPrinter.new(AnsiColors.BLUE)
 c.print("This text should be blue.")
 ```

--- a/index.wren
+++ b/index.wren
@@ -67,15 +67,15 @@ class AnsiColors {
 }
 
 class AnsiPrinter {
-  new (foreground) {
-    _modifiers = [foreground, null, null]
+  construct new (foreground) {
+    _modifiers = [foreground]
   }
 
-  new (foreground, background) {
-    _modifiers = [foreground, background, null]
+  construct new (foreground, background) {
+    _modifiers = [foreground, background]
   }
 
-  new (foreground, background, style) {
+  construct new (foreground, background, style) {
     _modifiers = [foreground, background, style]
   }
 
@@ -144,18 +144,9 @@ class AnsiPrinter {
   }
 
   printList_(objects) {
-    var setModifiers = _modifiers.where {|mod|
-      return mod
-    }
-
-    var modifierCodes = setModifiers.map {|mod|
-      return mod[2..(mod.count - 2)]
-    }
-
     // Set the styling for the forthcoming terminal output.
-    IO.writeString_("\u001b[" + modifierCodes.join(";") + "m")
-
-    IO.printList_(objects)
+    IO.write(_modifiers.join(""))
+    IO.printAll(objects)
 
     // Reset terminal styling.
     IO.writeString_(AnsiColors.RESET)


### PR DESCRIPTION
it's working for me now

<img width="409" alt="screen shot 2015-08-15 at 10 53 40 pm" src="https://cloud.githubusercontent.com/assets/820696/9291768/a03d8aea-43a0-11e5-9ccc-6a907786ffa0.png">

i might be doing something dumb here. it was breaking because `mod[2..(mod.count - 2)]` was being called where `mod is String`, but strings don't have that slice syntax yet. and i didn't understand what was going on here, but `"\u001b[" + modifierCodes.join(";") + "m"` was printing visible semicolons and an `m`.

let me know what you think!
